### PR TITLE
Ruboty ec2 verup

### DIFF
--- a/.env.bak
+++ b/.env.bak
@@ -1,0 +1,2 @@
+export REDISTOGO_URL=redis://localhost:6379/
+export RUBOTY_NAME=popy

--- a/.env.bak
+++ b/.env.bak
@@ -1,2 +1,0 @@
-export REDISTOGO_URL=redis://localhost:6379/
-export RUBOTY_NAME=popy

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '2.3.4'
+ruby '2.4.1'
 
 gem "rake"
 gem "ruboty-alias"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+ruby '2.3.4'
 
 gem "rake"
 gem "ruboty-alias"
@@ -8,6 +9,6 @@ gem "ruboty-redis"
 gem "ruboty-redis-info"
 gem "ruboty-slack"
 gem "ruboty-echo"
-gem 'ruboty-ec2', '0.8.2', :git => 'https://github.com/DreamArtsOkinawa/ruboty-ec2.git'
+gem 'ruboty-ec2', '0.8.3', :git => 'https://github.com/DreamArtsOkinawa/ruboty-ec2.git'
 gem 'ruboty-inc', '0.3.5', :git => 'https://github.com/DreamArtsOkinawa/ruboty-inc.git'
 gem 'ruboty-sdb', '0.1.5', :git => 'https://github.com/DreamArtsOkinawa/ruboty-sdb.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/DreamArtsOkinawa/ruboty-ec2.git
-  revision: 9b63058c80469f83b69df91d41b67c0ee9bb1887
+  revision: e9dbf79d3c15829b4ec74dda26d91e04b61e93e9
   specs:
-    ruboty-ec2 (0.8.2)
+    ruboty-ec2 (0.8.3)
       addressable
       aws-sdk (~> 2.0.0)
       ruboty
@@ -103,7 +103,7 @@ DEPENDENCIES
   rake
   ruboty-alias
   ruboty-cron
-  ruboty-ec2 (= 0.8.2)!
+  ruboty-ec2 (= 0.8.3)!
   ruboty-echo
   ruboty-google_image
   ruboty-inc (= 0.3.5)!
@@ -112,5 +112,8 @@ DEPENDENCIES
   ruboty-sdb (= 0.1.5)!
   ruboty-slack
 
+RUBY VERSION
+   ruby 2.3.4p301
+
 BUNDLED WITH
-   1.13.6
+   1.15.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ DEPENDENCIES
   ruboty-slack
 
 RUBY VERSION
-   ruby 2.3.4p301
+   ruby 2.4.1p111
 
 BUNDLED WITH
    1.15.1


### PR DESCRIPTION
ruboty-ec2 のコマンド結果出力のFQDNの頭に、"http://"を付与する。
rubyバージョンを2.3.4に指定する。