### PR TITLE
SpeedUp改修のバグ対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,6 @@ gem "ruboty-redis-info"
 #gem "ruboty-slack"
 gem "ruboty-echo"
 gem 'ruboty-cww', '0.8.12', :git => 'https://github.com/DreamArtsOkinawa/ruboty-cww.git'
-gem 'ruboty-ec2', '0.9.3', :git => 'https://github.com/DreamArtsOkinawa/ruboty-ec2.git'
+gem 'ruboty-ec2', '0.9.4', :git => 'https://github.com/DreamArtsOkinawa/ruboty-ec2.git'
 gem 'ruboty-inc', '0.3.5', :git => 'https://github.com/DreamArtsOkinawa/ruboty-inc.git'
 gem 'ruboty-sdb', '0.1.5', :git => 'https://github.com/DreamArtsOkinawa/ruboty-sdb.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,9 @@ GIT
 
 GIT
   remote: https://github.com/DreamArtsOkinawa/ruboty-ec2.git
-  revision: e06da234971f18178969101cfc930b505c2db1f5
+  revision: da4ea746c68efc1d6adb23cc67396788a1c7bcfe
   specs:
-    ruboty-ec2 (0.9.3)
+    ruboty-ec2 (0.9.4)
       addressable
       aws-sdk (~> 2.0.0)
       ruboty
@@ -106,7 +106,7 @@ DEPENDENCIES
   ruboty-alias
   ruboty-cron
   ruboty-cww (= 0.8.12)!
-  ruboty-ec2 (= 0.9.3)!
+  ruboty-ec2 (= 0.9.4)!
   ruboty-echo
   ruboty-google_image
   ruboty-inc (= 0.3.5)!


### PR DESCRIPTION
autostop exec にバグあり。
 filterで停止対象外のもの"tag:ExecptStopあり"のみを取得してしまったので、停止対象がなくなっていた。