### PR TITLE
ruboty-ec2 verup 0.9.6 + ruby 2.6.3 verup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '2.6.1'
+ruby '2.6.3'
 
 gem "rake"
 gem "ruboty-alias"

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,6 @@ gem "ruboty-redis-info"
 #gem "ruboty-slack"
 gem "ruboty-echo"
 gem 'ruboty-cww', '0.8.12', :git => 'https://github.com/DreamArtsOkinawa/ruboty-cww.git'
-gem 'ruboty-ec2', '0.9.5', :git => 'https://github.com/DreamArtsOkinawa/ruboty-ec2.git'
+gem 'ruboty-ec2', '0.9.6', :git => 'https://github.com/DreamArtsOkinawa/ruboty-ec2.git'
 gem 'ruboty-inc', '0.3.5', :git => 'https://github.com/DreamArtsOkinawa/ruboty-inc.git'
 gem 'ruboty-sdb', '0.1.5', :git => 'https://github.com/DreamArtsOkinawa/ruboty-sdb.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ DEPENDENCIES
   ruboty-sdb (= 0.1.5)!
 
 RUBY VERSION
-   ruby 2.6.1p33
+   ruby 2.6.3p62
 
 BUNDLED WITH
    1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,9 @@ GIT
 
 GIT
   remote: https://github.com/DreamArtsOkinawa/ruboty-ec2.git
-  revision: bb48170141e1743543cdc558bc337ca9008a84db
+  revision: ed2ae6ee852ef685f8a5face518e3c55e55e4adb
   specs:
-    ruboty-ec2 (0.9.5)
+    ruboty-ec2 (0.9.6)
       addressable
       aws-sdk (~> 2.0.0)
       ruboty
@@ -106,7 +106,7 @@ DEPENDENCIES
   ruboty-alias
   ruboty-cron
   ruboty-cww (= 0.8.12)!
-  ruboty-ec2 (= 0.9.5)!
+  ruboty-ec2 (= 0.9.6)!
   ruboty-echo
   ruboty-google_image
   ruboty-inc (= 0.3.5)!


### PR DESCRIPTION
ruboty-ec2 0.9.6 対応 自動起動対象インスタンスのDNS再登録コマンドなど追加、
ruby 2.6.3 verup 対応 werckerのbundle-installのruby versionに合わせた対応